### PR TITLE
feat: Modify deactivation flow for users

### DIFF
--- a/app.py
+++ b/app.py
@@ -314,9 +314,11 @@ def inject_global_vars():
     profile_form = None
     recent_notifications = []
     has_unread_notifications = False
+    is_deactivated = False
     
     if current_user.is_authenticated:
         profile_form = ProfileForm()
+        is_deactivated = not current_user.is_active
         
         # Check for any unread notifications to show the red dot
         has_unread_notifications = db.session.query(Transaction.id).filter_by(
@@ -356,7 +358,8 @@ def inject_global_vars():
         'current_year': dt_module.datetime.utcnow().year,
         'profile_form': profile_form,
         'recent_notifications': recent_notifications,
-        'has_unread_notifications': has_unread_notifications
+        'has_unread_notifications': has_unread_notifications,
+        'is_deactivated': is_deactivated
     }
 
 # App context and initial data setup
@@ -542,10 +545,6 @@ def login():
         customer = Customer.query.filter_by(username=form.username.data).first()
         if customer and check_password_hash(customer.password_hash, form.password.data):
 
-            if not customer.is_active:
-                flash('This account has been deactivated. Please contact support.', 'error')
-                return redirect(url_for('login'))
-            
             login_user(customer)
             # On successful login, redirect to the dashboard. The 'next' page logic can be added later if needed.
             return redirect(url_for('dashboard'))

--- a/static/css/spendables.css
+++ b/static/css/spendables.css
@@ -2202,3 +2202,21 @@ a.list-item:hover {
 .chat-message.is-agent {
   flex-direction: column; /* Allow timestamp to sit below */
 }
+
+/* Deactivated user styles */
+.deactivated button,
+.deactivated .btn,
+.deactivated a.btn,
+.deactivated input,
+.deactivated select,
+.deactivated textarea {
+    pointer-events: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.deactivated #deactivated-modal-close {
+    pointer-events: all;
+    opacity: 1;
+    cursor: pointer;
+}

--- a/static/js/spendables.js
+++ b/static/js/spendables.js
@@ -23,8 +23,32 @@ const App = {
     this.notificationHandler();
     this.virtualCard();
     this.liveChat();
+    this.deactivatedUserHandler();
 
     // Any other initializers can be added here
+  },
+
+  deactivatedUserHandler() {
+    const isDeactivated = document.body.classList.contains('deactivated');
+    if (!isDeactivated) return;
+
+    const modal = document.getElementById('deactivated-modal');
+    const closeBtn = document.getElementById('deactivated-modal-close');
+
+    if (!modal || !closeBtn) return;
+
+    document.addEventListener('click', (e) => {
+      // Check if the click is on a disabled element, but not the close button itself
+      if (e.target.closest('button, a.btn, input, select, textarea') && !e.target.closest('#deactivated-modal-close')) {
+        e.preventDefault();
+        e.stopPropagation();
+        modal.classList.add('is-visible');
+      }
+    }, true); // Use capture phase to catch event early
+
+    closeBtn.addEventListener('click', () => {
+      modal.classList.remove('is-visible');
+    });
   },
 
   /**

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
     <link rel="stylesheet" href="{{ ASSET_URL }}" />
     {% endassets %} {% block extra_css %}{% endblock %}
   </head>
-  <body class="{% block body_class %}{% endblock %}">
+  <body class="{% block body_class %}{% endblock %} {% if is_deactivated %}deactivated{% endif %}">
     <!-- ============================ -->
     <!-- HEADER -->
     <!-- ============================ -->
@@ -352,6 +352,22 @@
     <!-- MAIN CONTENT & FOOTER -->
     <!-- ============================ -->
     <main class="main-content-area">
+      {% if is_deactivated %}
+      <div id="deactivated-modal" class="modal-overlay is-visible">
+          <div class="modal-dialog">
+              <div class="modal-header">
+                  <h2><i class="fas fa-exclamation-triangle"></i> Account Deactivated</h2>
+              </div>
+              <div class="modal-body">
+                  <p>Your account has been deactivated. You have read-only access.</p>
+                  <p>Please contact customer support for further assistance.</p>
+              </div>
+              <div class="modal-footer">
+                  <button id="deactivated-modal-close" class="btn btn-primary">Understood</button>
+              </div>
+          </div>
+      </div>
+      {% endif %}
       {% with messages = get_flashed_messages(with_categories=true) %} {% if
       messages %}
       <div class="container" style="padding-top: var(--space-lg)">


### PR DESCRIPTION
This commit changes the user deactivation flow. Previously, deactivated users were prevented from logging in. Now, they can log in but will be presented with a restricted interface.

Changes:
- Modified the login route to allow deactivated users to log in.
- Added a global `is_deactivated` flag to templates.
- Added a modal to `base.html` to inform deactivated users of their account status.
- Added CSS to disable most interactive elements for deactivated users.
- Added JavaScript to show the deactivation modal on any interaction with disabled elements.