### PR TITLE
fix: Force login for deactivated users

### DIFF
--- a/app.py
+++ b/app.py
@@ -545,7 +545,7 @@ def login():
         customer = Customer.query.filter_by(username=form.username.data).first()
         if customer and check_password_hash(customer.password_hash, form.password.data):
 
-            login_user(customer)
+            login_user(customer, force=True)
             # On successful login, redirect to the dashboard. The 'next' page logic can be added later if needed.
             return redirect(url_for('dashboard'))
         else:


### PR DESCRIPTION
This commit fixes an issue where deactivated users were still unable to log in, despite the previous changes. The root cause was Flask-Login's default behavior of checking the `is_active` property on the user model and preventing login if it's `False`.

This fix uses `login_user(customer, force=True)` to bypass this default check, allowing deactivated users to log in and see the restricted interface as intended.