### PR TITLE
Fix: Chat widget position and mobile interactivity

### DIFF
--- a/static/css/spendables.css
+++ b/static/css/spendables.css
@@ -1874,10 +1874,10 @@ a.list-item:hover {
 
 /* === USER CHAT WIDGET === */
 .chat-widget {
-    position: fixed;
-    bottom: var(--space-lg);
-    right: var(--space-lg);
-    z-index: var(--z-chat-widget, 1050);
+    position: fixed !important;
+    bottom: var(--space-lg) !important;
+    right: var(--space-lg) !important;
+    z-index: 1050 !important;
     font-family: inherit;
 }
 
@@ -2356,8 +2356,7 @@ a.list-item:hover {
 /* Disable pointer events on the main content areas */
 .deactivated-dashboard .dashboard-main,
 .deactivated-dashboard .dashboard-sidebar,
-.deactivated-dashboard .summary-card,
-.deactivated-dashboard .dashboard-header {
+.deactivated-dashboard .summary-card {
     pointer-events: none;
 }
 


### PR DESCRIPTION
This commit addresses two issues:
1.  The chat widget is now correctly positioned in the bottom-right corner of the page.
2.  The mobile navigation, including the hamburger menu and other header links, is now interactive. This was fixed by removing a `pointer-events: none` rule that was incorrectly being applied to the header on mobile devices.

These fixes are in addition to the previous changes that restored the chat widget's toggle functionality and implemented cache-busting for static assets.