### PR TITLE
Fix: Move chat widget to bottom-left corner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Environment
+.env
+venv/
+env/
+
+# Logs
+*.log
+
+# Database
+*.db
+*.sqlite3
+
+# Flask / Assets
+.webassets-cache/
+static/gen/
+
+# OS / Editor
+.DS_Store
+.idea/
+.vscode/

--- a/static/css/spendables.css
+++ b/static/css/spendables.css
@@ -1876,7 +1876,7 @@ a.list-item:hover {
 .chat-widget {
     position: fixed !important;
     bottom: var(--space-lg) !important;
-    right: var(--space-lg) !important;
+    left: var(--space-lg) !important;
     z-index: 1050 !important;
     font-family: inherit;
 }


### PR DESCRIPTION
- Adjusted the CSS for the .chat-widget class to position it on the left side of the screen instead of the right.
- Added a .gitignore file to exclude logs, caches, and other generated files from version control.