### PR TITLE
Fix: Disable analytics and insights for all users

### DIFF
--- a/app.py
+++ b/app.py
@@ -797,16 +797,16 @@ def mark_notifications_as_read():
 @app.route('/api/spending-analytics')
 @login_required
 def spending_analytics():
-    # Placeholder data. In Phase 4, this will be a real database query.
-    data = { 
-        "labels": ["Groceries", "Utilities", "Transport", "Entertainment", "Shopping"],
+    # Per user request, this feature is disabled for all users for now.
+    # Always return empty data.
+    return jsonify({
+        "labels": [],
         "datasets": [{
             "label": "Spending by Category",
-            "data": [350.50, 180.25, 120.00, 250.75, 400.00],
-            "backgroundColor": ["#00A36C", "#FFD700", "#C0C0C0", "#2F4F4F", "#F5F5F5"]
+            "data": [],
+            "backgroundColor": []
         }]
-    }
-    return jsonify(data)
+    })
 
 @app.route('/api/user_details/<int:customer_id>')
 @login_required

--- a/templates/banking/dashboard.html
+++ b/templates/banking/dashboard.html
@@ -83,12 +83,12 @@ content %}
         <section class="card card--interactive anim-fade-in-up">
           <header class="card-header">
             <h2 class="card-title">Spending Analytics</h2>
-            <select class="form-input" style="width: auto" {% if not recent_transactions %}disabled{% endif %}>
+            <select class="form-input" style="width: auto" disabled>
               <option>Last 30 Days</option>
               <option>Last 90 Days</option>
             </select>
           </header>
-          {% if recent_transactions %}
+          {% if false %}
           <div class="chart-container">
             <canvas id="spendingChart"></canvas>
           </div>
@@ -241,7 +241,7 @@ content %}
           <header class="card-header">
             <h2 class="card-title">Financial Insights</h2>
           </header>
-          {% if recent_transactions %}
+          {% if false %}
           <div class="list">
             <div class="list-item">
               <div class="list-item-icon icon-warning">


### PR DESCRIPTION
This commit disables the 'Spending Analytics' and 'Financial Insights' features for all users, including admins, as per the user's clarified request.

- The `/api/spending-analytics` endpoint in `app.py` has been modified to always return an empty data structure, ensuring no analytics data is ever sent to the client.
- The `dashboard.html` template has been updated to permanently show the empty state for both the analytics and insights sections by changing the rendering condition to `{% if false %}`. This guarantees a consistent, data-free display for everyone.